### PR TITLE
Fix incorrect link label

### DIFF
--- a/specification/draft/enterprise-managed-authorization.mdx
+++ b/specification/draft/enterprise-managed-authorization.mdx
@@ -38,7 +38,7 @@ This profile is an application of the "Identity Assertion Authorization Grant" [
 The Identity Assertion Authorization Grant follows three steps:
 
 1. Single Sign-On to the MCP Client via OpenID Connect or SAML
-2. Token Exchange ([RFC8623](https://datatracker.ietf.org/doc/html/rfc8693))
+2. Token Exchange ([RFC8693](https://datatracker.ietf.org/doc/html/rfc8693))
 3. JWT Authorization Grant ([RFC7523](https://datatracker.ietf.org/doc/html/rfc7523))
 
 The core flow is as follows:


### PR DESCRIPTION
## Motivation and Context

The specification for "OAuth 2.0 Token Exchange" is RFC 8693. https://datatracker.ietf.org/doc/html/rfc8623 refers to a different specification, so the current link is correct. This PR fixes the incorrect link label.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed
