### PR TITLE
Update oauth-client-credentials.mdx

### DIFF
--- a/specification/draft/oauth-client-credentials.mdx
+++ b/specification/draft/oauth-client-credentials.mdx
@@ -119,10 +119,11 @@ POST /token HTTP/1.1
 Host: auth.example.com
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
-&assertion=eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0.
-    eyJpc3Mi[...omitted for brevity...].
-    J9l-ZhwP[...omitted for brevity...]
+grant_type=client_credentials
+&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+&client_assertion=eyJhbGciOiJSUzI1NiIsImtpZCI6IjIyIn0.
+     eyJpc3Mi[...omitted for brevity...].
+     cC4hiUPo[...omitted for brevity...]
 &resource=https%3A%2F%2Fmcp.example.com
 &scope=mcp%3Aread
 ```

--- a/specification/draft/oauth-client-credentials.mdx
+++ b/specification/draft/oauth-client-credentials.mdx
@@ -58,7 +58,7 @@ Clients **MUST** authenticate using one of these methods:
 - Client Secret
   - Clients use a Client Secret transmitted in the request content as defined
     in
-    [OAuth 2.1 Section 2.4.1](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-client-secret)
+    [OAuth 2.1 Section 4.2](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#name-client-credentials-grant)
 
 ### Server Metadata Requirements
 

--- a/specification/draft/oauth-client-credentials.mdx
+++ b/specification/draft/oauth-client-credentials.mdx
@@ -119,11 +119,10 @@ POST /token HTTP/1.1
 Host: auth.example.com
 Content-Type: application/x-www-form-urlencoded
 
-grant_type=client_credentials
-&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
-&client_assertion=eyJhbGciOiJSUzI1NiIsImtpZCI6IjIyIn0.
-     eyJpc3Mi[...omitted for brevity...].
-     cC4hiUPo[...omitted for brevity...]
+grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
+&assertion=eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0.
+    eyJpc3Mi[...omitted for brevity...].
+    J9l-ZhwP[...omitted for brevity...]
 &resource=https%3A%2F%2Fmcp.example.com
 &scope=mcp%3Aread
 ```


### PR DESCRIPTION
Oauth 2.1 2.4.1 is about client id and secret:
https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#section-2.4.1

> To support clients in possession of a client secret, the authorization server MUST support the client including the client credentials in the request body content using the following parameters:

>"client_id":
REQUIRED. The client identifier issued to the client during the registration process described by [Section 2.2](https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#client-identifier).

>"client_secret":
REQUIRED. The client secret.


But I think we want to explicitly reference the Client Credentials grant in 4.2:
> The client can request an access token using only its client credentials (or other supported means of authentication) when the client is requesting access to the protected resources under its control, or those of another resource owner that have been previously arranged with the authorization server (the method of which is beyond the scope of this specification).